### PR TITLE
Initialize config.container_config in case it's undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 tmp/
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.4.2] - 2023-01-19
+
+### Fixed
+- Initialize `config.container_config` in case it's `undefined` 
+
 ## [0.4.1] - 2022-03-24
 
 ### Dependency update / security

--- a/appLayerCreator.js
+++ b/appLayerCreator.js
@@ -199,6 +199,7 @@ async function addLayers(tmpdir, fromdir, todir, options) {
   logger.info('Parsing image ...');
   let manifest = await fse.readJson(path.join(fromdir, 'manifest.json'));
   let config = await fse.readJson(path.join(fromdir, 'config.json'));
+  config.container_config = config.container_config || {};
 
   logger.info('Adding new layers...');
   await copyLayers(fromdir, todir, manifest.layers);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doqr",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Build node.js docker images without docker",
   "main": "./cli.js",
   "scripts": {


### PR DESCRIPTION
I'm experiencing an issue where `config.container_config` is `undefined` when trying to set the `option.user` and `options.labels`.

It could be that I'm using `doqr` wrong, but this fixes my issue.