### PR TITLE
feat(config): Added support for config as .json-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.6.0] - 2022-02-03
+
+### Added
+- Support for config as .json-file
+
 ## [0.5.0] - 2022-01-19
 
 ### Added


### PR DESCRIPTION
Added support for using a .json-file to input config.

Defaults to `doqr.json` if found on path given by `--folder` argument, but can be overridden with the `--file` argument similar to `docker build . --file <Dockerfile>`.

CLI arguments take precedence over config-file arguments. Environment variables and labels are additive.

Resolves #5 