### PR TITLE
feat: Support for OCI Image Index and Docker Manifest List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.1.0] - 2023-03-04
+
+### Added
+
+- Support for OCI Image Index (application/vnd.oci.image.index.v1)
+- Support for OCI Image Manifest (application/vnd.oci.image.manifest.v1)
+- Support for Docker Manifest List (application/vnd.docker.distribution.manifest.list.v2)
+- Option for selecting preferred platform (OS and architecture) similar to Docker 
+
 ## [1.0.4] - 2023-02-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Support for Docker Manifest List (application/vnd.docker.distribution.manifest.list.v2)
 - Option for selecting preferred platform (OS and architecture) similar to Docker 
 
+### Improvement
+
+- Add `doqr` version in manifest history `created_by` field
+
 ## [1.0.4] - 2023-02-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Options:
   --toToken <token>              Optional: Authentication token for target registry
   --toTar <path>                 Optional: Export to tar file
   --registry <path>              Optional: Convenience argument for setting both from and to registry
+  --platform <platform>          Optional: Preferred platform, e.g. linux/amd64 or arm64
   --token <path>                 Optional: Convenience argument for setting token for both from and to registry
   --user <user>                  Optional: User account to run process in container - default: 1000
   --workdir <directory>          Optional: Workdir where node app will be added and run from - default: /app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "doqr",
-	"version": "1.0.4",
+	"version": "1.1.0",
 	"description": "Build node.js docker images without docker",
 	"main": "./lib/cli.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"main": "./lib/cli.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",
+		"prebuild": "node -p \"'export const VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
 		"build": "tsc && chmod ugo+x lib/cli.js",
 		"lint": "eslint . --ext .ts --fix --ignore-path .gitignore",
 		"typecheck": "tsc --noEmit",

--- a/src/MIMETypes.ts
+++ b/src/MIMETypes.ts
@@ -1,0 +1,31 @@
+interface MIMETypes {
+    index: string,
+    manifest: string,
+    layer: LayerTypes,
+    config: string,
+}
+
+interface LayerTypes {
+    tar: string,
+    gzip: string
+}
+
+export const OCI: MIMETypes = {
+    index: 'application/vnd.oci.image.index.v1+json',
+    manifest: 'application/vnd.oci.image.manifest.v1+json',
+    layer: {
+        tar: 'application/vnd.oci.image.layer.v1.tar',
+        gzip: 'application/vnd.oci.image.layer.v1.tar+gzip'
+    },
+    config: 'application/vnd.oci.image.config.v1+json'
+}
+
+export const DockerV2: MIMETypes = {
+    index: 'application/vnd.docker.distribution.manifest.list.v2+json',
+    manifest: 'application/vnd.docker.distribution.manifest.v2+json',
+    layer: {
+        tar: 'application/vnd.docker.image.rootfs.diff.tar',
+        gzip: 'application/vnd.docker.image.rootfs.diff.tar.gzip',
+    },
+    config: 'application/vnd.docker.container.image.v1+json'
+}

--- a/src/appLayerCreator.ts
+++ b/src/appLayerCreator.ts
@@ -10,7 +10,7 @@ import * as fileutil from "./fileutil";
 import logger from "./logger";
 import { Config, Layer, Manifest, Options } from "./types";
 import {getManifestLayerType, getLayerTypeFileEnding, unique} from "./utils";
-import {DockerV2, OCI} from "./MIMETypes";
+import { VERSION } from "./version";
 
 const depLayerPossibles = ["package.json", "package-lock.json", "node_modules"];
 
@@ -156,7 +156,7 @@ async function addDataLayer(
 	config.rootfs.diff_ids.push("sha256:" + dhash);
 	config.history.push({
 		created: options.setTimeStamp || new Date().toISOString(),
-		created_by: "doqr",
+		created_by: `doqr:${VERSION}`,
 		comment: comment,
 	});
 }

--- a/src/appLayerCreator.ts
+++ b/src/appLayerCreator.ts
@@ -9,7 +9,8 @@ import { Gunzip } from "minizlib";
 import * as fileutil from "./fileutil";
 import logger from "./logger";
 import { Config, Layer, Manifest, Options } from "./types";
-import { unique } from "./utils";
+import {getManifestLayerType, getLayerTypeFileEnding, unique} from "./utils";
+import {DockerV2, OCI} from "./MIMETypes";
 
 const depLayerPossibles = ["package.json", "package-lock.json", "node_modules"];
 
@@ -107,7 +108,7 @@ async function addDataLayer(
 	todir: string,
 	options: Options,
 	config: Config,
-	layers: Array<Layer>,
+	manifest: Manifest,
 	files: Array<string | Array<string>>,
 	comment: string,
 ) {
@@ -146,8 +147,8 @@ async function addDataLayer(
 	const fhash = await calculateHash(layerFile);
 	const finalName = path.join(todir, fhash + ".tar.gz");
 	await fse.move(layerFile, finalName);
-	layers.push({
-		mediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+	manifest.layers.push({
+		mediaType: getManifestLayerType(manifest),
 		size: await fileutil.sizeOf(finalName),
 		digest: "sha256:" + fhash,
 	});
@@ -163,7 +164,7 @@ async function addDataLayer(
 async function copyLayers(fromdir: string, todir: string, layers: Array<Layer>) {
 	await Promise.all(
 		layers.map(async (layer) => {
-			const file = layer.digest.split(":")[1] + (layer.mediaType.includes("tar.gzip") ? ".tar.gz" : ".tar");
+			const file = layer.digest.split(":")[1] + getLayerTypeFileEnding(layer);
 			await fse.copy(path.join(fromdir, file), path.join(todir, file));
 		}),
 	);
@@ -184,7 +185,7 @@ async function addAppLayers(options: Options, config: Config, todir: string, man
 	if (options.customContent) {
 		await addEnvsLayer(options, config);
 		await addLabelsLayer(options, config);
-		await addDataLayer(tmpdir, todir, options, config, manifest.layers, options.customContent, "custom");
+		await addDataLayer(tmpdir, todir, options, config, manifest, options.customContent, "custom");
 	} else {
 		addEmptyLayer(
 			config,
@@ -209,12 +210,12 @@ async function addAppLayers(options: Options, config: Config, todir: string, man
 		const depLayerContent = appFiles.filter((l) => depLayerPossibles.includes(l));
 		const appLayerContent = appFiles.filter((l) => !depLayerPossibles.includes(l));
 
-		await addDataLayer(tmpdir, todir, options, config, manifest.layers, depLayerContent, "dependencies");
-		await addDataLayer(tmpdir, todir, options, config, manifest.layers, appLayerContent, "app");
+		await addDataLayer(tmpdir, todir, options, config, manifest, depLayerContent, "dependencies");
+		await addDataLayer(tmpdir, todir, options, config, manifest, appLayerContent, "app");
 	}
 	if (options.extraContent) {
 		for (const i in options.extraContent) {
-			await addDataLayer(tmpdir, todir, options, config, manifest.layers, [options.extraContent[i]], "extra");
+			await addDataLayer(tmpdir, todir, options, config, manifest, [options.extraContent[i]], "extra");
 		}
 	}
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import tarExporter from "./tarExporter";
 
 import logger from "./logger";
 import { Options } from "./types";
-import { omit } from "./utils";
+import { omit, getPreferredPlatform } from "./utils";
 import { ensureEmptyDir } from "./fileutil";
 
 const possibleArgs = {
@@ -28,6 +28,7 @@ const possibleArgs = {
 	"--toToken <token>": "Optional: Authentication token for target registry",
 	"--toTar <path>": "Optional: Export to tar file",
 	"--registry <path>": "Optional: Convenience argument for setting both from and to registry",
+	"--platform <platform>": "Optional: Preferred platform, e.g. linux/amd64 or arm64",
 	"--token <path>": "Optional: Convenience argument for setting token for both from and to registry",
 	"--user <user>": "Optional: User account to run process in container - default: 1000",
 	"--workdir <directory>": "Optional: Workdir where node app will be added and run from - default: /app",
@@ -220,7 +221,7 @@ async function run(options: Options) {
 	const fromRegistry = options.fromRegistry
 		? createRegistry(options.fromRegistry, options.fromToken ?? "")
 		: createDockerRegistry(options.fromToken);
-	await fromRegistry.download(options.fromImage, fromdir);
+	await fromRegistry.download(options.fromImage, fromdir, getPreferredPlatform(options.platform));
 
 	await appLayerCreator.addLayers(tmpdir, fromdir, todir, options);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,27 @@ export type Image = {
 	tag: string;
 };
 
+// https://github.com/opencontainers/image-spec/blob/v1.0/image-index.md
+// https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list
+export type Index = {
+	mediaType: string;
+	schemaVersion: string;
+	manifests: Array<IndexManifest>;
+	annotations?: Map<string, string>;
+}
+
+export type IndexManifest = {
+	mediaType: string;
+	digest: string;
+	size: number;
+	platform: Platform;
+}
+
+export type Platform = {
+	architecture: string;
+	os: string;
+}
+
 export type Manifest = {
 	config: {
 		digest: string;
@@ -26,6 +47,8 @@ export type PartialManifestConfig = {
 };
 
 export type Config = {
+	architecture?: string;
+	os?: string;
 	history: Array<HistoryLine>;
 	rootfs: {
 		diff_ids: string[];
@@ -62,6 +85,7 @@ export type Options = {
 	toToken?: string;
 	toTar?: string;
 	registry?: string;
+	platform: string;
 	token?: string;
 	user: string;
 	workdir: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import { Platform } from "./types";
+import logger from "./logger";
+
 export function unique(vals: string[]): string[] {
 	return [...new Set(vals)];
 }
@@ -10,3 +13,69 @@ export function omit<T>(
 		Object.entries(obj).filter(([k]) => !keys.includes(k)),
 	);
 }
+export function getPreferredPlatform(platform?: string): Platform {
+	// We assume the input is similar to docker which accepts `<os>/<arch>` and `<arch>`
+	let os = ''
+	let arch = ''
+
+	if (platform != undefined) {
+		const input = platform.split('/')
+		if (input.length == 1) {
+			os = process.platform
+			arch = input[0];
+		}
+		if (input.length > 1) {
+			os = input[0];
+			arch = input[1];
+		}
+	} else {
+		os = process.platform
+		arch = process.arch
+	}
+
+	// Mapping from Node's process.platform and Golang's `$GOOS` to Golang's `$GOOS`
+	// Incomplete, but cover the most common OS-types
+	// https://nodejs.org/api/process.html#processplatform
+	// https://go.dev/doc/install/source#environment
+	const OS_MAPPING = {
+		aix: 'aix',
+		darwin: 'darwin',
+		freebsd: 'freebsd',
+		linux: 'linux',
+		openbsd: 'openbsd',
+		sunos: 'solaris',
+		solaris: 'solaris',
+		win32: 'windows',
+		windows: 'windows'
+	}
+
+	if (!(os in OS_MAPPING)) {
+		logger.error(`Platform ${os} not supported. Supported platforms are '${Object.keys(OS_MAPPING)}`)
+		process.exit(1);
+	}
+
+	// Mapping from Node's `process.arch` and Golang's `$GOARCH` to Golang's `$GOARCH` (incomplete)
+	// Incomplete, but cover the most common architectures
+	// https://nodejs.org/api/process.html#processarch
+	// https://go.dev/doc/install/source#environment
+	const ARCH_MAPPING = {
+		ia32: '386',
+		'386': '386',
+		x64: 'amd64',
+		amd64: 'amd64',
+		arm: 'arm',
+		arm64: 'arm64'
+	}
+
+	if (!(arch in ARCH_MAPPING)) {
+		logger.error(`Architecture ${arch} not supported. Supported architectures are '${Object.keys(ARCH_MAPPING)}'.`)
+		process.exit(1)
+	}
+
+	return {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore We handle missing keys above, so this should be OK
+		os: OS_MAPPING[os], architecture: ARCH_MAPPING[arch]
+	}
+}
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { Platform } from "./types";
-import logger from "./logger";
 
 export function unique(vals: string[]): string[] {
 	return [...new Set(vals)];
@@ -50,8 +49,7 @@ export function getPreferredPlatform(platform?: string): Platform {
 	}
 
 	if (!(os in OS_MAPPING)) {
-		logger.error(`Platform ${os} not supported. Supported platforms are '${Object.keys(OS_MAPPING)}`)
-		process.exit(1);
+		throw new Error(`Platform ${os} not supported. Supported platforms are '${Object.keys(OS_MAPPING)}`)
 	}
 
 	// Mapping from Node's `process.arch` and Golang's `$GOARCH` to Golang's `$GOARCH` (incomplete)
@@ -68,8 +66,7 @@ export function getPreferredPlatform(platform?: string): Platform {
 	}
 
 	if (!(arch in ARCH_MAPPING)) {
-		logger.error(`Architecture ${arch} not supported. Supported architectures are '${Object.keys(ARCH_MAPPING)}'.`)
-		process.exit(1)
+		throw new Error(`Architecture ${arch} not supported. Supported architectures are '${Object.keys(ARCH_MAPPING)}'.`)
 	}
 
 	return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { Platform } from "./types";
+import {Layer, Manifest, Platform} from "./types";
+import {DockerV2, OCI} from "./MIMETypes";
 
 export function unique(vals: string[]): string[] {
 	return [...new Set(vals)];
@@ -73,6 +74,29 @@ export function getPreferredPlatform(platform?: string): Platform {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore We handle missing keys above, so this should be OK
 		os: OS_MAPPING[os], architecture: ARCH_MAPPING[arch]
+	}
+}
+
+export function getManifestLayerType(manifest: Manifest) {
+	if (manifest.mediaType === OCI.manifest) {
+		return OCI.layer.gzip
+	}
+	if (manifest.mediaType === DockerV2.manifest) {
+		return DockerV2.layer.gzip
+	}
+	throw new Error(`${manifest.mediaType} not recognized.`)
+}
+
+export function getLayerTypeFileEnding(layer: Layer) {
+	switch (layer.mediaType) {
+		case OCI.layer.gzip:
+		case DockerV2.layer.gzip:
+			return '.tar.gz'
+		case OCI.layer.tar:
+		case DockerV2.layer.tar:
+			return '.tar'
+		default:
+			throw new Error(`Layer mediaType ${layer.mediaType} not known.`)
 	}
 }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "1.1.0";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
 		"module": "commonjs",
 		"declaration": true,
 		"outDir": "./lib",
-		"strict": true
+		"strict": true,
+		"resolveJsonModule": true
 	},
 	"include": ["src"],
 	"exclude": ["node_modules", "**/__tests__/*"]


### PR DESCRIPTION
OCI Image Index and Docker Manifest List are lists of manifests using the same tag, but built for different platforms (OS/architecture). This commit adds support for both types of lists/indexes and a way of selecting a preferred platform with a fallback to only architecture similar to how Docker solves this problem.

This is by no means perfect and fully platform complete so input is welcome.

Tested to work on a `darwin/arm64` machine pulling from an OCI Image Index pointing to an OCI Image Manifest for the `linux/amd64` platform.

Resolves #21 

Sources:
OCI Image Index and Docker Manifest List
https://github.com/opencontainers/image-spec/blob/v1.0/image-index.md
https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list
https://specs.opencontainers.org/image-spec/image-index/?v=v1.0.1

Docker architecture fallback (I think)
https://github.com/moby/moby/pull/41955/commits/50f39e724707ef121a988e422eb52045d3754802#diff-d4214d9a77c1e79e410c9e3f898bfac27ca8041b6798ab0242b7fb36f4e66ff5

Platform representations in Go and Node
https://go.dev/doc/install/source#environment
https://nodejs.org/api/process.html#processplatform
https://nodejs.org/api/process.html#processarch